### PR TITLE
Fix search issue with full token symbol name

### DIFF
--- a/src/components/SearchModal/CurrencySearch.tsx
+++ b/src/components/SearchModal/CurrencySearch.tsx
@@ -95,8 +95,7 @@ export function CurrencySearch({
       ...filteredTokens.filter((token) => token.symbol?.includes('SOKU') || token.symbol?.includes('SUTEKU')),
 
       ...sorted.filter(
-        (token) =>
-          token.symbol?.toLowerCase() !== symbolMatch[0] && token.symbol !== 'SOKU' && token.symbol !== 'SUTEKU'
+        (token) => token.symbol !== 'SOKU' && token.symbol !== 'SUTEKU'
       ),
     ]
   }, [filteredTokens, searchQuery, searchToken, tokenComparator])


### PR DESCRIPTION
- fix missing searched token, while using full token symbol name in
  search input, by updating filter logic of sorted token list